### PR TITLE
FIX: synch timer across tabs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "puma", "~> 6.0"
 gem "jsbundling-rails"
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails", ">= 2.0.5"
+gem "turbo-rails", ">= 2.0.10"
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,10 +358,9 @@ GEM
     thor (1.3.1)
     tilt (2.4.0)
     timeout (0.4.3)
-    turbo-rails (2.0.5)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
+    turbo-rails (2.0.16)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -428,7 +427,7 @@ DEPENDENCIES
   stimulus-rails
   strong_migrations
   tailwind_merge (~> 1.2)
-  turbo-rails (>= 2.0.5)
+  turbo-rails (>= 2.0.10)
   tzinfo-data
   web-console
   webdrivers

--- a/app/models/time_reg.rb
+++ b/app/models/time_reg.rb
@@ -6,6 +6,7 @@ class TimeReg < ApplicationRecord
   has_paper_trail
   belongs_to :user
   belongs_to :assigned_task
+  broadcasts_refreshes
 
   has_one :project, through: :assigned_task
   has_one :task, through: :assigned_task, source: :task

--- a/app/views/time_regs/_time_reg.html.erb
+++ b/app/views/time_regs/_time_reg.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_stream_from time_reg %>
 <%= content_tag(:div, id: dom_id(time_reg), data: { controller: "refresh-minutes", refresh_minutes_active_value: time_reg.active?, refresh_minutes_minutes_value: time_reg.current_minutes, refresh_minutes_format_value: "H:mm" }, class: "shadow-sm rounded-md p-4 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-y-4") do %>
   <div class="flex flex-row gap-x-4">
     <div class="bg-gray-50 border border-gray-100 rounded flex justify-center items-center w-12 h-12 relative">


### PR DESCRIPTION
## In this PR
Fixes the bug discussed in issue: #371
### The fix
* Added `broadcasts_refreshes` to `TimeReg` model, that triggers the `time_regs/index` page to refresh whenever the state of a `time_reg` changes (e.g. the timer state).
* Updated `turbo-rails` version, as the current version includes a `sidekiq`-bug that breaks the turbo streaming. [(#535)](https://github.com/hotwired/turbo-rails/issues/535)