### PR TITLE
Add invisible captcha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,8 @@ gem "discard"
 
 gem "sendgrid-ruby"
 
+gem "invisible_captcha"
+
 gem "devise_invitable", "~> 2.0.9"
 
 gem "sidekiq", "~> 7.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
       railties (>= 7.0.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.3.0)
+      rails (>= 5.2)
     io-console (0.6.0)
     irb (1.6.4)
       reline (>= 0.3.0)
@@ -403,6 +405,7 @@ DEPENDENCIES
   discard
   dotenv-rails (~> 2.1, >= 2.1.1)
   hotwire-livereload
+  invisible_captcha
   jbuilder
   jsbundling-rails
   letter_opener

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  invisible_captcha prepend: true, only: [ :create ], on_spam: :handle_spam, on_timestamp_spam: :handle_spam, scope: :user
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :first_name, :last_name ])
+  end
+
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  def create
+    super
+  end
+
+  private
+
+  def handle_spam
+    flash[:notice] = t("devise.registrations.signed_up")
+    redirect_to root_path
+  end
+
+
+
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+  #
+  #
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,6 +6,7 @@
       <div class="w-full flex gap-y-4 flex-col mt-4">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
         <%= form.hidden_field :locale, value: I18n.locale %>
+        <%= form.invisible_captcha %>
         <div class="flex flex-col w-full gap-y-4 lg:gap-y-8 mb-4">
           <%= render RubyUI::FormField.new(class: "flex flex-col") do  %>
             <%= render RubyUI::FormFieldLabel.new { t("registration.first_name") } %>

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,5 @@
+InvisibleCaptcha.setup do |config|
+  config.timestamp_enabled = !Rails.env.test?
+  config.spinner_enabled = !Rails.env.test?
+  config.honeypots = [ "honeypot_field" ] if Rails.env.test?
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { invitations: "users/invitations" }
+  devise_for :users, controllers: { invitations: "users/invitations", registrations: "users/registrations" }
 
   authenticated :user do
     root to: "time_regs#index", as: :authenticated_root

--- a/test/integration/users/regirstrations_integration_test.rb
+++ b/test/integration/users/regirstrations_integration_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Users::RegistrationsIntegrationTest < ActionDispatch::IntegrationTest
+  test "should create user" do
+    user_count = User.count
+
+    post user_registration_path, params: {
+      user: {
+        locale: "en",
+        first_name: "Test",
+        last_name: "Name",
+        email: "test@test",
+        password: "123123",
+        password_confirmation: "123123"
+      }
+    }
+
+    assert_equal (user_count + 1), User.count
+  end
+
+  test "should not create bot user" do
+    user_count = User.count
+
+    post user_registration_path, params: {
+      user: {
+        locale: "en",
+        first_name: "Test",
+        last_name: "Name",
+        email: "test@test",
+        password: "123123",
+        password_confirmation: "123123",
+        honeypot_field: "bot data"
+      }
+    }
+
+    assert_response :redirect
+    assert_equal user_count, User.count
+  end
+end


### PR DESCRIPTION
## In this PR
Implements the (invisible_captcha gem)[https://github.com/markets/invisible_captcha] to prevent the annoying bot signups to our site.

The gem adds an input field that is invisible to a real user, but visible to a bot.
Then the signup process secretly fails if this field is populated.