### PR TITLE
Add bot protection in reset password form

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,10 @@
+class Users::PasswordsController < Devise::PasswordsController
+  invisible_captcha prepend: true, only: [ :create ], on_spam: :handle_spam, on_timestamp_spam: :handle_spam, scope: :user
+
+  private
+
+  def handle_spam
+    flash[:notice] = t("devise.passwords.send_instructions")
+    redirect_to new_user_session_path
+  end
+end

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,6 +11,7 @@
           <%= render RubyUI::FormField.new(class: "flex flex-col") do  %>
             <%= render RubyUI::FormFieldLabel.new { t("activerecord.attributes.user.email") } %>
             <%= form.email_field :email, autofocus: true, autocomplete: "email", required: true, placeholder: t("activerecord.attributes.user.email"), class: "border-gray-200 rounded-md w-full" %>
+            <%= form.invisible_captcha %>
           <% end %>
         </div>
         <%= render ButtonComponent.new(type: "submit") { t("password_reset.new.send_instructions") } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { invitations: "users/invitations", registrations: "users/registrations" }
+  devise_for :users, controllers: {
+    invitations: "users/invitations",
+    registrations: "users/registrations",
+    passwords: "users/passwords"
+  }
 
   authenticated :user do
     root to: "time_regs#index", as: :authenticated_root

--- a/test/integration/password_reset_integration_test.rb
+++ b/test/integration/password_reset_integration_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class PasswordResetIntegrationTest < ActionDispatch::IntegrationTest
+  test "should start reset password process when requested" do
+    user = users(:joe)
+    assert_nil user.reset_password_token
+    assert_nil user.reset_password_sent_at
+
+    post user_password_path, params: {
+      user: { email: user.email }
+    }
+
+    user.reload
+    assert_not_nil user.reset_password_token
+    assert_not_nil user.reset_password_sent_at
+    assert_in_delta Time.current, user.reset_password_sent_at, 1.minute
+  end
+
+  test "should not start reset password process when requested by a bot" do
+    user = users(:joe)
+    assert_nil user.reset_password_token
+    assert_nil user.reset_password_sent_at
+
+    post user_password_path, params: {
+      user: {
+        email: user.email,
+        honeypot_field: "bot data"
+      }
+    }
+
+    user.reload
+    assert_nil user.reset_password_token
+    assert_nil user.reset_password_sent_at
+  end
+end


### PR DESCRIPTION
## In this PR
Added the `invisible_captcha` field in the reset password form, to prevent bots from validating emails in the database.