### PR TITLE
Extend project access table

### DIFF
--- a/app/models/project_access.rb
+++ b/app/models/project_access.rb
@@ -1,7 +1,7 @@
 class ProjectAccess < ApplicationRecord
   belongs_to :project
   belongs_to :access_info
-  belongs_to :invited_by, class_name: 'User', optional: true
+  belongs_to :invited_by, class_name: "User", optional: true
   has_one :organization, through: :access_info
 
   validates :project_id, uniqueness: { scope: :access_info_id }

--- a/app/models/project_access.rb
+++ b/app/models/project_access.rb
@@ -1,10 +1,12 @@
 class ProjectAccess < ApplicationRecord
   belongs_to :project
   belongs_to :access_info
+  belongs_to :invited_by, class_name: 'User', optional: true
   has_one :organization, through: :access_info
 
   validates :project_id, uniqueness: { scope: :access_info_id }
   validate :user_is_project_restricted
+  validate :external_invitation_fields_present_if_external
 
   private
 
@@ -12,5 +14,17 @@ class ProjectAccess < ApplicationRecord
     unless access_info.project_restricted?
       errors.add(:access_info, "User is not project restricted and can not have any ProjectAccesses.")
     end
+  end
+
+  def external_invitation_fields_present_if_external
+    if external?
+      if invited_by_id.blank? || invitation_token.blank? || invited_at.blank?
+        errors.add(:base, "External invitations must have invited_by, invitation_token, and invited_at")
+      end
+    end
+  end
+
+  def external?
+    access_info.organization != project.organization
   end
 end

--- a/db/migrate/20250619161030_add_external_invitation_fields_to_project_accesses.rb
+++ b/db/migrate/20250619161030_add_external_invitation_fields_to_project_accesses.rb
@@ -1,0 +1,24 @@
+class AddExternalInvitationFieldsToProjectAccesses < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_column :project_accesses, :invited_by_id, :bigint
+    add_column :project_accesses, :invitation_token, :string
+    add_column :project_accesses, :invited_at, :datetime
+    add_column :project_accesses, :accepted_at, :datetime
+
+    add_index :project_accesses, :invitation_token, unique: true, algorithm: :concurrently
+    add_foreign_key :project_accesses, :users, column: :invited_by_id, validate: false, algorithm: :concurrently
+    validate_foreign_key :project_accesses, :users, column: :invited_by_id
+  end
+
+  def down
+    remove_foreign_key :project_accesses, column: :invited_by_id
+    remove_index :project_accesses, :invitation_token
+
+    remove_column :project_accesses, :accepted_at, :datetime
+    remove_column :project_accesses, :invited_at, :datetime
+    remove_column :project_accesses, :invitation_token, :string
+    remove_column :project_accesses, :invited_by_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_18_134314) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_19_161030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,7 +60,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_18_134314) do
     t.bigint "access_info_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invited_by_id"
+    t.string "invitation_token"
+    t.datetime "invited_at"
+    t.datetime "accepted_at"
     t.index ["access_info_id"], name: "index_project_accesses_on_access_info_id"
+    t.index ["invitation_token"], name: "index_project_accesses_on_invitation_token", unique: true
     t.index ["project_id", "access_info_id"], name: "index_project_accesses_on_project_id_and_access_info_id", unique: true
     t.index ["project_id"], name: "index_project_accesses_on_project_id"
   end
@@ -145,6 +150,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_18_134314) do
   add_foreign_key "clients", "organizations"
   add_foreign_key "project_accesses", "access_infos"
   add_foreign_key "project_accesses", "projects"
+  add_foreign_key "project_accesses", "users", column: "invited_by_id"
   add_foreign_key "projects", "clients"
   add_foreign_key "tasks", "organizations"
   add_foreign_key "time_regs", "assigned_tasks"


### PR DESCRIPTION
**Description**
Expand the `project_access` table, to allow invites form external organizations in the future.
This PR is one of multiple steps.

**Related Issue**
#324 

**Changes Made**
List the major changes introduced by this PR:
1. On table `project_accesses`:
  1. Added field `invited_by_id`
  2. Added field `invitation_token`
  3. Added field `invited_at`
  4. Added field `accepted_at`
2. On model `ProjectAccess`:
  1. Added validation for invitation fields
  2. Added method `external?`
