### PR TITLE
Add project intivation service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+**Setup:**
+```bash
+bundle install
+rails assets:precompile
+rails db:create
+rails db:migrate
+yarn install
+rails db:fixtures:load  # Populate with test data
+```
+
+**Running the application:**
+```bash
+bin/dev  # Starts Rails server, JS/CSS watchers, and Sidekiq via Foreman
+```
+
+**Prerequisites:** Redis must be running (`redis-server --daemonize yes`)
+
+**Testing:**
+```bash
+bin/rake test     # Run all tests
+bin/rubocop       # Run linter
+bin/rubocop -a    # Auto-fix linting issues
+```
+
+## Architecture Overview
+
+**Tech Stack:** Ruby on Rails 7.1, PostgreSQL, Hotwire (Turbo + Stimulus), Tailwind CSS, Phlex components, Sidekiq with Redis
+
+**Multi-tenant Architecture:** Organization-based data isolation with role-based access control (admin, member, spectator)
+
+**Core Models:**
+- Organizations → Clients → Projects → AssignedTasks
+- Users ↔ AccessInfo ↔ Organizations (many-to-many with roles)
+- TimeRegs (time entries) linked to users, projects, and tasks
+- ProjectAccess for granular project-level permissions
+
+## Critical Authorization Rules
+
+This application uses ActionPolicy with strict data isolation requirements:
+
+1. **ALWAYS use `authorized_scope`** when querying databases to prevent data leakage
+2. **Use `authorize!` in EVERY controller action** and create policies for every action
+3. **Multi-tenant scoping is mandatory** - all queries must respect organization boundaries
+
+Example:
+```ruby
+def index
+  authorize!
+  @clients = authorized_scope(Client, type: :relation).all
+end
+
+def show
+  @client = authorized_scope(Client, type: :relation).find(params[:id])
+  authorize! @client
+end
+```
+
+## Key Components
+
+**Frontend:** 
+- Phlex components in `/app/components/` with RubyUI component library
+- Stimulus controllers in `/app/javascript/controllers/`
+- Tailwind CSS with custom configuration
+
+**Background Jobs:** Sidekiq with Redis (required for Hotwire functionality)
+
+**Invitation System:** devise_invitable for user invitations with external project access
+
+## Current Context
+
+**Active Branch:** `feature/invite-to-project/external-user-invitation`
+**Purpose:** Extending project access for external user invitations
+**Main Branch:** `main`

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,21 @@ class UserMailer < Devise::Mailer
     )
   end
 
+  def project_invitation_email(project_invitation:, inviting_user:, project:)
+    mail(
+      to: project_invitation.invited_email,
+      sendgrid_template: Stemplin.config.emails.templates[:user][:project_invitation][I18n.locale][:template_id],
+      content: {
+        inviting_user_name: inviting_user.name,
+        inviting_organization_name: inviting_user.current_organization.name,
+        project_name: project.name,
+        client_name: project.client.name,
+        accept_url: "", # accept_project_invitation_url(token: project_invitation.invitation_token),
+        reject_url: "" # reject_project_invitation_url(token: project_invitation.invitation_token)
+      }
+    )
+  end
+
   # @Note: This overrides `reset_password_instructions` from Devise::Mailer to send a sendgrid template
   # this implementations sends over a url with the `reset_password_token`
   # I think this is something Sendgrid should be handling well, but if it poses security concerns

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,6 +17,7 @@ class Project < ApplicationRecord
   has_many :project_accesses, dependent: :destroy
   has_many :access_infos, through: :project_accesses
   has_many :users, through: :access_infos
+  has_many :project_invitations, dependent: :destroy
 
   accepts_nested_attributes_for :assigned_tasks, allow_destroy: true
 

--- a/app/models/project_access.rb
+++ b/app/models/project_access.rb
@@ -1,12 +1,23 @@
 class ProjectAccess < ApplicationRecord
   belongs_to :project
   belongs_to :access_info
-  belongs_to :invited_by, class_name: "User", optional: true
   has_one :organization, through: :access_info
 
   validates :project_id, uniqueness: { scope: :access_info_id }
   validate :user_is_project_restricted
-  validate :external_invitation_fields_present_if_external
+
+  scope :external_access, -> {
+    joins(:access_info, project: { client: :organization })
+    .where.not("access_infos.organization_id = organizations.id")
+  }
+
+  def user
+    access_info.user
+  end
+
+  def external?
+    access_info.organization != project.organization
+  end
 
   private
 
@@ -14,17 +25,5 @@ class ProjectAccess < ApplicationRecord
     unless access_info.project_restricted?
       errors.add(:access_info, "User is not project restricted and can not have any ProjectAccesses.")
     end
-  end
-
-  def external_invitation_fields_present_if_external
-    if external?
-      if invited_by_id.blank? || invitation_token.blank? || invited_at.blank?
-        errors.add(:base, "External invitations must have invited_by, invitation_token, and invited_at")
-      end
-    end
-  end
-
-  def external?
-    access_info.organization != project.organization
   end
 end

--- a/app/models/project_invitation.rb
+++ b/app/models/project_invitation.rb
@@ -1,0 +1,118 @@
+class ProjectInvitation < ApplicationRecord
+  belongs_to :project
+  belongs_to :invited_by, class_name: "User"
+  belongs_to :accepted_as_access_info, class_name: "AccessInfo", optional: true
+
+  validates :invited_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :invitation_token, presence: true, uniqueness: true
+  validates :invited_email, uniqueness: { scope: :project_id, message: "has already been invited to this project" }
+  validates :invited_at, presence: true
+
+  validate :cannot_invite_same_organization_user
+  validate :only_one_status_at_a_time
+
+  scope :pending, -> { where(accepted_at: nil, rejected_at: nil) }
+  scope :accepted, -> { where.not(accepted_at: nil) }
+  scope :rejected, -> { where.not(rejected_at: nil) }
+  scope :expired, -> { where("expires_at < ?", Time.current) }
+  scope :active, -> { pending.where("expires_at > ?", Time.current) }
+
+  before_validation :set_expires_at, on: :create
+  before_validation :generate_invitation_token, on: :create
+
+  def pending?
+    accepted_at.nil? && rejected_at.nil? && !expired?
+  end
+
+  def accepted?
+    accepted_at.present?
+  end
+
+  def rejected?
+    rejected_at.present?
+  end
+
+  def expired?
+    expires_at && expires_at < Time.current
+  end
+
+  def can_be_accepted?
+    pending? && !expired?
+  end
+
+  def accept!(organization)
+    raise "Cannot accept expired or already processed invitation" unless can_be_accepted?
+
+    transaction do
+      # Find or create user
+      user = User.find_by(email: invited_email)
+
+      if user.nil?
+        user = User.create!(
+          email: invited_email,
+          first_name: "External",
+          last_name: "User",
+          password: SecureRandom.hex(16),
+          locale: I18n.default_locale.to_s
+        )
+      end
+
+      # Find or create access_info for the user in the selected organization
+      access_info = user.access_infos.find_or_create_by(organization: organization) do |ai|
+        ai.role = :organization_user
+      end
+
+      # Create the project access
+      project_access = ProjectAccess.create!(
+        project: project,
+        access_info: access_info
+      )
+
+      # Mark invitation as accepted
+      update!(
+        accepted_at: Time.current,
+        accepted_as_access_info: access_info
+      )
+
+      project_access
+    end
+  end
+
+  def reject!
+    raise "Cannot reject expired or already processed invitation" unless can_be_accepted?
+
+    update!(rejected_at: Time.current)
+  end
+
+  def invited_user
+    @invited_user ||= User.find_by(email: invited_email)
+  end
+
+  def invited_user_organizations
+    return Organization.none unless invited_user
+    invited_user.organizations
+  end
+
+  private
+
+  def set_expires_at
+    self.expires_at ||= 7.days.from_now
+  end
+
+  def generate_invitation_token
+    self.invitation_token ||= SecureRandom.urlsafe_base64(32)
+  end
+
+  def cannot_invite_same_organization_user
+    return unless invited_user&.organizations&.include?(project.organization)
+
+    errors.add(:invited_email, "cannot invite users from the same organization")
+  end
+
+  def only_one_status_at_a_time
+    status_count = [ accepted_at, rejected_at ].compact.count
+    if status_count > 1
+      errors.add(:base, "invitation cannot be both accepted and rejected")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :clients, through: :organizations
   has_many :projects, through: :clients
   has_many :project_accesses, through: :access_infos
+  has_many :sent_project_invitations, class_name: "ProjectInvitation", foreign_key: "invited_by_id"
 
   scope :ordered_by_name, -> { order(:first_name, :last_name) }
   scope :ordered_by_role, -> { joins(:access_infos).select("users.*, access_infos.role").order("access_infos.role ASC") }

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -7,6 +7,10 @@ class ProjectPolicy < ApplicationPolicy
     user.organization_admin? && user.current_organization == record.organization
   end
 
+  def invite_external_user?
+    user.organization_admin? && user.current_organization == record.organization
+  end
+
   scope_for :relation, :own do |relation|
     organization = user.current_organization
     relation = relation.joins(client: :organization).where(organizations: { id: organization.id })

--- a/app/services/project_invitation_service.rb
+++ b/app/services/project_invitation_service.rb
@@ -1,0 +1,97 @@
+class ProjectInvitationService
+  include ActionPolicy::Behaviour
+  include Rails.application.routes.url_helpers
+
+  attr_reader :project, :email, :inviting_user
+
+  def initialize(project:, email:, inviting_user:)
+    @project = project
+    @email = email.strip.downcase
+    @inviting_user = inviting_user
+  end
+
+  def call
+    begin
+      return false unless can_invite?
+      return false if same_organization?
+
+      ActiveRecord::Base.transaction do
+        create_project_invitation
+        send_invitation_email
+      end
+
+      true
+    rescue => e
+      Rails.logger.error "Project invitation failed: #{e.message}"
+      false
+    end
+  end
+
+  def self.accept_invitation(invitation_token, organization)
+    begin
+      invitation = ProjectInvitation.find_by(invitation_token: invitation_token)
+      return false unless invitation
+      return false unless invitation.can_be_accepted?
+
+      invitation.accept!(organization)
+      true
+    rescue => e
+      Rails.logger.error "Project invitation acceptance failed: #{e.message}"
+      false
+    end
+  end
+
+  def self.reject_invitation(invitation_token)
+    begin
+      invitation = ProjectInvitation.find_by(invitation_token: invitation_token)
+      return false unless invitation
+      return false unless invitation.can_be_accepted?
+
+      invitation.reject!
+      true
+    rescue => e
+      Rails.logger.error "Project invitation rejection failed: #{e.message}"
+      false
+    end
+  end
+
+  private
+
+  def can_invite?
+    authorize! @project, to: :invite_external_user?
+    true
+  rescue ActionPolicy::Unauthorized
+    false
+  end
+
+  def same_organization?
+    invited_user = User.find_by(email: @email)
+    return false unless invited_user&.organizations&.include?(@project.organization)
+    true
+  end
+
+  def create_project_invitation
+    @project_invitation = ProjectInvitation.create!(
+      project: @project,
+      invited_email: @email,
+      invited_by: @inviting_user,
+      invited_at: Time.current
+    )
+  end
+
+  def send_invitation_email
+    UserMailer.project_invitation_email(
+      project_invitation: @project_invitation,
+      inviting_user: @inviting_user,
+      project: @project
+    ).deliver_later
+  end
+
+  def implicit_authorization_target
+    @project
+  end
+
+  def default_url_options
+    Rails.application.config.action_mailer.default_url_options
+  end
+end

--- a/config/emails.yml
+++ b/config/emails.yml
@@ -8,6 +8,11 @@ shared:
           template_id: "d-f78bbd2312eb4e62904e90813cddfde9"
         en:
           template_id: "d-f78bbd2312eb4e62904e90813cddfde9"
+      project_invitation:
+        nb:
+          template_id: "d-660209244f7e464e9ac4eed8f670e73d"
+        en:
+          template_id: "d-660209244f7e464e9ac4eed8f670e73d"
       password_reset:
         nb:
           template_id: "d-7738fd5757d5497ca4973e572ba4b26e"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,11 @@ Rails.application.routes.draw do
   resources :reports, only: [ :index ]
   get "reports/detailed", to: "reports#detailed", as: :detailed_reports
 
+  # Project invitation routes
+  # get "project_invitations/:token/accept", to: "project_invitations#show", as: :accept_project_invitation
+  # post "project_invitations/:token/accept", to: "project_invitations#accept"
+  # post "project_invitations/:token/reject", to: "project_invitations#reject", as: :reject_project_invitation
+
 
   # PWA routes
 

--- a/db/migrate/20250626134240_create_project_invitations.rb
+++ b/db/migrate/20250626134240_create_project_invitations.rb
@@ -1,0 +1,25 @@
+class CreateProjectInvitations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :project_invitations do |t|
+      t.bigint :project_id, null: false
+      t.string :invited_email, null: false
+      t.bigint :invited_by_id, null: false
+      t.string :invitation_token, null: false
+      t.datetime :invited_at, null: false
+      t.datetime :accepted_at
+      t.datetime :rejected_at
+      t.datetime :expires_at
+      t.bigint :accepted_as_access_info_id
+      t.timestamps
+
+      t.index :invitation_token, unique: true
+      t.index [ :invited_email, :project_id ], unique: true
+      t.index :project_id
+      t.index :accepted_as_access_info_id
+    end
+
+    add_foreign_key :project_invitations, :projects, validate: false
+    add_foreign_key :project_invitations, :users, column: :invited_by_id, validate: false
+    add_foreign_key :project_invitations, :access_infos, column: :accepted_as_access_info_id, validate: false
+  end
+end

--- a/db/migrate/20250626134607_remove_invitation_fields_from_project_accesses.rb
+++ b/db/migrate/20250626134607_remove_invitation_fields_from_project_accesses.rb
@@ -1,0 +1,23 @@
+class RemoveInvitationFieldsFromProjectAccesses < ActiveRecord::Migration[7.1]
+  def up
+    remove_foreign_key :project_accesses, column: :invited_by_id
+    remove_index :project_accesses, :invitation_token
+
+    safety_assured do
+      remove_column :project_accesses, :accepted_at, :datetime
+      remove_column :project_accesses, :invited_at, :datetime
+      remove_column :project_accesses, :invitation_token, :string
+      remove_column :project_accesses, :invited_by_id, :bigint
+    end
+  end
+
+  def down
+    add_column :project_accesses, :invited_by_id, :bigint
+    add_column :project_accesses, :invitation_token, :string
+    add_column :project_accesses, :invited_at, :datetime
+    add_column :project_accesses, :accepted_at, :datetime
+
+    add_index :project_accesses, :invitation_token, unique: true
+    add_foreign_key :project_accesses, :users, column: :invited_by_id
+  end
+end

--- a/db/migrate/20250626134835_validate_project_invitations_foreign_keys.rb
+++ b/db/migrate/20250626134835_validate_project_invitations_foreign_keys.rb
@@ -1,0 +1,7 @@
+class ValidateProjectInvitationsForeignKeys < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :project_invitations, :projects
+    validate_foreign_key :project_invitations, :users, column: :invited_by_id
+    validate_foreign_key :project_invitations, :access_infos, column: :accepted_as_access_info_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_19_161030) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_26_134835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,14 +60,27 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_19_161030) do
     t.bigint "access_info_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "invited_by_id"
-    t.string "invitation_token"
-    t.datetime "invited_at"
-    t.datetime "accepted_at"
     t.index ["access_info_id"], name: "index_project_accesses_on_access_info_id"
-    t.index ["invitation_token"], name: "index_project_accesses_on_invitation_token", unique: true
     t.index ["project_id", "access_info_id"], name: "index_project_accesses_on_project_id_and_access_info_id", unique: true
     t.index ["project_id"], name: "index_project_accesses_on_project_id"
+  end
+
+  create_table "project_invitations", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.string "invited_email", null: false
+    t.bigint "invited_by_id", null: false
+    t.string "invitation_token", null: false
+    t.datetime "invited_at", null: false
+    t.datetime "accepted_at"
+    t.datetime "rejected_at"
+    t.datetime "expires_at"
+    t.bigint "accepted_as_access_info_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["accepted_as_access_info_id"], name: "index_project_invitations_on_accepted_as_access_info_id"
+    t.index ["invitation_token"], name: "index_project_invitations_on_invitation_token", unique: true
+    t.index ["invited_email", "project_id"], name: "index_project_invitations_on_invited_email_and_project_id", unique: true
+    t.index ["project_id"], name: "index_project_invitations_on_project_id"
   end
 
   create_table "projects", force: :cascade do |t|
@@ -150,7 +163,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_19_161030) do
   add_foreign_key "clients", "organizations"
   add_foreign_key "project_accesses", "access_infos"
   add_foreign_key "project_accesses", "projects"
-  add_foreign_key "project_accesses", "users", column: "invited_by_id"
+  add_foreign_key "project_invitations", "access_infos", column: "accepted_as_access_info_id"
+  add_foreign_key "project_invitations", "projects"
+  add_foreign_key "project_invitations", "users", column: "invited_by_id"
   add_foreign_key "projects", "clients"
   add_foreign_key "tasks", "organizations"
   add_foreign_key "time_regs", "assigned_tasks"

--- a/test/services/project_invitation_service_test.rb
+++ b/test/services/project_invitation_service_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ProjectInvitationServiceTest < ActiveSupport::TestCase
+  def setup
+    @project = projects(:project_1)
+    @admin_user = users(:organization_admin)
+    @external_email = "consultant@stemplin.com"
+    @external_org = organizations(:organization_two)
+  end
+
+  test "full invitation workflow" do
+    # Test 1: Create invitation manually (skip service call for now)
+    invitation = ProjectInvitation.create!(
+      project: @project,
+      invited_email: @external_email,
+      invited_by: @admin_user,
+      invited_at: Time.current
+    )
+
+    # Test 2: Invitation gets created
+    assert invitation.persisted?, "ProjectInvitation should be saved"
+    assert_equal @project, invitation.project
+    assert_equal @admin_user, invitation.invited_by
+    assert invitation.invitation_token.present?, "Should have invitation token"
+    assert invitation.pending?, "Invitation should be pending"
+
+    # Test 3: Invitation can be accepted
+    begin
+      result = ProjectInvitationService.accept_invitation(invitation.invitation_token, @external_org)
+      assert result, "Invitation acceptance should return true"
+    rescue => e
+      puts "Acceptance failed with error: #{e.message}"
+      puts "Invitation can_be_accepted?: #{invitation.can_be_accepted?}"
+      puts "Invitation pending?: #{invitation.pending?}"
+      puts "Invitation expired?: #{invitation.expired?}"
+      raise e
+    end
+
+    invitation.reload
+    assert invitation.accepted?, "Invitation should be accepted"
+    assert_equal @external_org, invitation.accepted_as_access_info.organization
+
+    # Test 4: Invited user has access to the project
+    project_access = ProjectAccess.joins(:access_info)
+                                  .where(project: @project, access_infos: { organization: @external_org })
+                                  .first
+    assert project_access, "ProjectAccess should be created"
+    assert_equal @external_email, project_access.user.email
+  end
+end


### PR DESCRIPTION
**Description**
Adds a service to create, send and accept an invitation to an external project.
Includes also a restructuring of project invitations.

**Related Issue**
#324

**Changes Made**
1. Added `ProjectInvitation` model
2. Removed invitation fields from the `project_accesses` table
3. Added `ProjectInvitationService` to handle sending/accepting/rejecting an invitation.
4. Updated `UserMailer` to send project invitation
5. Added new Sendgrid template
6. Added a `CLAUDE.md` file

