### PR TITLE
Remove closest modal

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -17,13 +17,17 @@ StreamActions.remove_modal = function() {
   const elementToRemove = document.getElementById(target);
   console.log(elementToRemove)
   if (elementToRemove) {
+    const specificDialog = elementToRemove.closest('div[data-controller="ruby-ui--dialog"]');
+
     elementToRemove.remove();
-    const dismissableDivs = document.querySelectorAll('div[data-controller="ruby-ui--dialog"]');
-    dismissableDivs?.forEach((el) => el?.remove());
+
+    if (specificDialog) {
+      specificDialog.remove();
+    }
+
     document?.body?.classList?.remove("overflow-hidden");
   }
 }
-
 Turbo.setConfirmMethod((message, element) => {
   const dialog = document.getElementById("turbo-confirm-dialog");
 


### PR DESCRIPTION
**Description**
Stopping the organization switch from disappear when creating a new client 

**Related Issue**
[Disappearing organization switch #406](https://github.com/rubynor/stemplin/issues/406)

**Changes Made**
List the major changes introduced by this PR:
1. Added/Updated/Removed ...
2. Refactored ...
3. Improved ...

**How to Test**
Steps to test this Pull Request:
1. Navigate to [Workspace](http://localhost:3000/workspace/projects)
2. Create a new client

