### PR TITLE
Add API token generation to the account settings page

### DIFF
--- a/app/controllers/users/api_tokens_controller.rb
+++ b/app/controllers/users/api_tokens_controller.rb
@@ -1,21 +1,14 @@
 class Users::ApiTokensController < AuthenticatedController
-  # The Devise registrations edit view relies on these helpers.
-  helper_method :resource, :resource_name
-
   def create
     authorize! current_user, to: :regenerate_token?, with: UserPolicy
 
+    # The plaintext token exists only in this response (a turbo_stream swap of
+    # the section, 200 OK) — it is never placed in the flash/session/cookies.
     @api_token = current_user.regenerate_api_token!
-    render "devise/registrations/edit", status: :unprocessable_entity
-  end
-
-  private
-
-  def resource
-    current_user
-  end
-
-  def resource_name
-    :user
+    render turbo_stream: turbo_stream.replace(
+      :api_token_section,
+      partial: "users/api_tokens/section",
+      locals: { user: current_user, api_token: @api_token }
+    )
   end
 end

--- a/app/controllers/users/api_tokens_controller.rb
+++ b/app/controllers/users/api_tokens_controller.rb
@@ -1,0 +1,21 @@
+class Users::ApiTokensController < AuthenticatedController
+  # The Devise registrations edit view relies on these helpers.
+  helper_method :resource, :resource_name
+
+  def create
+    authorize! current_user, to: :regenerate_token?, with: UserPolicy
+
+    @api_token = current_user.regenerate_api_token!
+    render "devise/registrations/edit", status: :unprocessable_entity
+  end
+
+  private
+
+  def resource
+    current_user
+  end
+
+  def resource_name
+    :user
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -46,28 +46,7 @@
       </div>
     <% end %>
 
-    <span class="text-xl font-semibold text-gray-600 mt-8"><%= t("api_token.title") %></span>
-    <span class="text-sm text-gray-400"><%= t("api_token.usage_hint") %></span>
-    <% if @api_token.present? %>
-      <div class="flex flex-col gap-y-2 mt-2 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
-        <span class="text-sm font-semibold text-yellow-800"><%= t("api_token.one_time_notice") %></span>
-        <code class="font-mono text-sm select-all break-all"><%= @api_token %></code>
-      </div>
-    <% end %>
-    <span class="text-sm text-gray-600 mt-2">
-      <%= resource.api_token_digest? ? t("api_token.status_present") : t("api_token.status_absent") %>
-    </span>
-    <div class="mt-2">
-      <% if resource.api_token_digest? %>
-        <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path, form: { data: { turbo_confirm: t("api_token.regenerate_confirm") } }) do %>
-          <%= t("api_token.regenerate") %>
-        <% end %>
-      <% else %>
-        <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path) do %>
-          <%= t("api_token.generate") %>
-        <% end %>
-      <% end %>
-    </div>
+    <%= render "users/api_tokens/section", user: resource, api_token: @api_token %>
 
     <%= link_to t("common.back"), root_path, class: "mt-3 underline hover:text-primary" %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -45,6 +45,30 @@
         <%= link_to t('registration.cancel_account'), registration_path(resource_name), class: "text-red-600 hover:underline", data: { turbo_method: :delete, turbo_confirm: t('notice.are_you_sure') }  %>
       </div>
     <% end %>
+
+    <span class="text-xl font-semibold text-gray-600 mt-8"><%= t("api_token.title") %></span>
+    <span class="text-sm text-gray-400"><%= t("api_token.usage_hint") %></span>
+    <% if @api_token.present? %>
+      <div class="flex flex-col gap-y-2 mt-2 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
+        <span class="text-sm font-semibold text-yellow-800"><%= t("api_token.one_time_notice") %></span>
+        <code class="font-mono text-sm select-all break-all"><%= @api_token %></code>
+      </div>
+    <% end %>
+    <span class="text-sm text-gray-600 mt-2">
+      <%= resource.api_token_digest? ? t("api_token.status_present") : t("api_token.status_absent") %>
+    </span>
+    <div class="mt-2">
+      <% if resource.api_token_digest? %>
+        <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path, form: { data: { turbo_confirm: t("api_token.regenerate_confirm") } }) do %>
+          <%= t("api_token.regenerate") %>
+        <% end %>
+      <% else %>
+        <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path) do %>
+          <%= t("api_token.generate") %>
+        <% end %>
+      <% end %>
+    </div>
+
     <%= link_to t("common.back"), root_path, class: "mt-3 underline hover:text-primary" %>
   </div>
 </div>

--- a/app/views/users/api_tokens/_section.html.erb
+++ b/app/views/users/api_tokens/_section.html.erb
@@ -1,0 +1,26 @@
+<%# One-time token display: api_token is only ever non-nil in the response to
+    the generate/regenerate action — it is never persisted or shown again. %>
+<div id="api_token_section" class="flex flex-col">
+  <span class="text-xl font-semibold text-gray-600 mt-8"><%= t("api_token.title") %></span>
+  <span class="text-sm text-gray-400"><%= t("api_token.usage_hint") %></span>
+  <% if api_token.present? %>
+    <div class="flex flex-col gap-y-2 mt-2 p-4 bg-yellow-50 border border-yellow-300 rounded-md">
+      <span class="text-sm font-semibold text-yellow-800"><%= t("api_token.one_time_notice") %></span>
+      <code class="font-mono text-sm select-all break-all"><%= api_token %></code>
+    </div>
+  <% end %>
+  <span class="text-sm text-gray-600 mt-2">
+    <%= user.api_token_digest? ? t("api_token.status_present") : t("api_token.status_absent") %>
+  </span>
+  <div class="mt-2">
+    <% if user.api_token_digest? %>
+      <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path, form: { data: { turbo_confirm: t("api_token.regenerate_confirm") } }) do %>
+        <%= t("api_token.regenerate") %>
+      <% end %>
+    <% else %>
+      <%= render ButtonComponent.new(variant: :outline, method: :post, path: users_api_token_path) do %>
+        <%= t("api_token.generate") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,16 @@ en:
     cannot_be_undone: "This action cannot be undone."
 
 
+  api_token:
+    title: "API token"
+    usage_hint: "Use the token as \"Authorization: Bearer <token>\" against the API at /api/v1/."
+    status_present: "An API token exists for your account."
+    status_absent: "No API token has been generated yet."
+    generate: "Generate API token"
+    regenerate: "Regenerate API token"
+    regenerate_confirm: "Are you sure? Your old API token will stop working immediately."
+    one_time_notice: "Save this token now — it will not be shown again."
+
   registration:
     first_name: "First name"
     last_name: "Last name"

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -383,6 +383,16 @@ nb:
     cannot_be_undone: "Denne handlingen kan ikke bli tatt tilbake."
 
 
+  api_token:
+    title: "API-token"
+    usage_hint: "Bruk tokenet som «Authorization: Bearer <token>» mot API-et på /api/v1/."
+    status_present: "Det finnes et API-token for kontoen din."
+    status_absent: "Det er ikke generert noe API-token ennå."
+    generate: "Generer API-token"
+    regenerate: "Generer nytt API-token"
+    regenerate_confirm: "Er du sikker? Det gamle API-tokenet slutter å virke umiddelbart."
+    one_time_notice: "Lagre dette tokenet nå — det vises ikke igjen."
+
   registration:
     first_name: "Fornavn"
     last_name: "Etternavn"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
     root to: "time_regs#index", as: :authenticated_root
   end
 
+  namespace :users do
+    resource :api_token, only: :create
+  end
+
   root to: redirect("users/sign_in")
 
   get "privacy-policy", to: "privacy_policy#index", as: :privacy_policy

--- a/test/controllers/users/api_tokens_controller_test.rb
+++ b/test/controllers/users/api_tokens_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Users::ApiTokensControllerTest < ActionController::TestCase
+  def setup
+    @user = users(:ron)
+  end
+
+  test "unauthenticated create redirects to sign in" do
+    post :create
+
+    assert_redirected_to new_user_session_path
+    assert_nil @user.reload.api_token_digest
+  end
+
+  test "create changes digest and shows token exactly once with warning" do
+    sign_in @user
+
+    post :create
+
+    assert_response :unprocessable_entity
+    token = assigns(:api_token)
+    assert token.present?
+    assert_equal 1, response.body.scan(token).count
+    assert_includes response.body, I18n.t("api_token.one_time_notice")
+    assert_equal Digest::SHA256.hexdigest(token), @user.reload.api_token_digest
+  end
+
+  test "regenerating invalidates previous token" do
+    old_token = @user.regenerate_api_token!
+    sign_in @user
+
+    post :create
+
+    assert_nil User.find_by_api_token(old_token)
+    assert_equal @user, User.find_by_api_token(assigns(:api_token))
+  end
+end

--- a/test/controllers/users/api_tokens_controller_test.rb
+++ b/test/controllers/users/api_tokens_controller_test.rb
@@ -17,7 +17,8 @@ class Users::ApiTokensControllerTest < ActionController::TestCase
 
     post :create
 
-    assert_response :unprocessable_entity
+    assert_response :ok
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
     token = assigns(:api_token)
     assert token.present?
     assert_equal 1, response.body.scan(token).count

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Users::RegistrationsControllerTest < ActionController::TestCase
+  def setup
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    @user = users(:ron)
+    sign_in @user
+  end
+
+  test "edit page never shows a token on plain visit" do
+    @user.regenerate_api_token!
+
+    get :edit
+
+    assert_response :success
+    assert_not_includes response.body, I18n.t("api_token.one_time_notice")
+    assert_includes response.body, I18n.t("api_token.regenerate")
+  end
+
+  test "edit page offers to generate a token when none exists" do
+    get :edit
+
+    assert_response :success
+    assert_includes response.body, I18n.t("api_token.status_absent")
+    assert_includes response.body, I18n.t("api_token.generate")
+  end
+end


### PR DESCRIPTION
Closes #450

## What
An **API token** section on the account page (`/users/edit`):

- Shows whether a token exists (from `api_token_digest?` — nothing derived from the digest is ever displayed).
- **Generate API token** — or **Regenerate** with a `turbo_confirm` warning that the old token stops working — POSTs to a new session-authenticated `Users::ApiTokensController#create`, which calls the existing `User#regenerate_api_token!`.
- The new token is shown **once**, in a highlighted copy-friendly block with a "save it now" notice, plus a short hint about `Authorization: Bearer <token>` against `/api/v1/`.

## Security notes
- The plaintext token lives only in the single response render (`@api_token` ivar) — it is never placed in the flash, session, cookies, params, or logs, and never persisted beyond its digest.
- Action is authenticated (`AuthenticatedController`) and authorized (`UserPolicy#regenerate_token?`).
- No changes to the API itself — digest storage and `PATCH /api/v1/api_token` untouched.

## Tests
`255 runs, 0 failures, 0 errors` (full suite). New coverage: unauthenticated POST rejected; authenticated POST rotates the digest and shows the one-time token exactly once with the warning copy; regeneration invalidates the previous token; the edit page never displays a token on a plain visit. Locales added in both `en` and `nb`. Rubocop clean.

---
*PR generated by Claude on behalf of @l3x4.*